### PR TITLE
Pass url to cy.request if no baseUrl

### DIFF
--- a/support.js
+++ b/support.js
@@ -28,7 +28,7 @@ Cypress.Commands.add('api', (options, name = 'api') => {
   const messagesEndpoint = Cypress._.get(
     Cypress.env(),
     'cyApi.messages',
-    '/__messages__'
+    `${options.url ?? '' }/__messages__`
   )
 
   // first reset any messages on the server


### PR DESCRIPTION
I ran into https://github.com/bahmutov/cy-api/issues/59 and saw that the issue was the resetting messages before the url property was used.