### PR TITLE
fix(tag-pre): break overflowing words

### DIFF
--- a/support.js
+++ b/support.js
@@ -76,6 +76,10 @@ Cypress.Commands.add('api', (options, name = 'api') => {
           text-align: left;
           margin-top: 1em;
         }
+        .cy-api-pre {
+          word-break: break-all;
+          white-space: normal;
+        }
       </style>
     `
   } else {
@@ -89,7 +93,7 @@ Cypress.Commands.add('api', (options, name = 'api') => {
     `<h1 class="cy-api-request" style="margin: ${topMargin} 0 1em">Cy-api: ${name}</h1>\n` +
     '<div>\n' +
     '<b>Request:</b>\n' +
-    '<pre>' +
+    '<pre class="cy-api-pre">' +
     JSON.stringify(options, null, 2) +
     '\n</pre></div>'
 


### PR DESCRIPTION
This pr aims to fix the overflowing text within the `pre` tag

___

- Before:
![image](https://user-images.githubusercontent.com/5674833/94991176-31d29c80-0579-11eb-9438-1a776d3e5ec9.png)


- After:
![image](https://user-images.githubusercontent.com/5674833/94991166-1ebfcc80-0579-11eb-8f4a-24c18b1d9cae.png)
