### PR TITLE
Correction in README.md for new env var name API_MESSAGES

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This will add a new command `cy.api` for making API requests.
 
 ## Configuration
 
-If you want to disable messages calls use an environment variable `CYPRESS_API_MESSAGE=false`.
+If you want to disable messages calls use an environment variable `API_MESSAGES=false`.
 
 ## TypeScript
 


### PR DESCRIPTION
`CYPRESS_API_MESSAGE=false` replaced by `API_MESSAGES=false`