### PR TITLE
Simplify code implementation

### DIFF
--- a/support.js
+++ b/support.js
@@ -28,7 +28,7 @@ Cypress.Commands.add('api', (options, name = 'api') => {
     container.className = 'container'
     doc.body.appendChild(container)
   }
-  const messagesEndpoint = Cypress._.get(
+  const messagesEndpoint = get(
     Cypress.env(),
     'cyApi.messages',
     '/__messages__'


### PR DESCRIPTION
The `get` method has already been destructured from `Cypress._` on line 11, and so it can be used directly.