### PR TITLE
fix: Auth password return object.

### DIFF
--- a/src/support.ts
+++ b/src/support.ts
@@ -292,7 +292,8 @@ const formatJSon = (jsonObject: object) => {
 
 const formatRequest = (options: Partial<Cypress.RequestOptions>) => {
   const showCredentials = Cypress.env('API_SHOW_CREDENTIALS');
-  const hasPassword = options?.auth?.password;
+  const auth = options?.auth as { username?: string, password?: string }
+  const hasPassword = auth?.password;
   if (!showCredentials && hasPassword) {
     return formatJSon({
       ...options,

--- a/src/support.ts
+++ b/src/support.ts
@@ -292,12 +292,15 @@ const formatJSon = (jsonObject: object) => {
 
 const formatRequest = (options: Partial<Cypress.RequestOptions>) => {
   const showCredentials = Cypress.env('API_SHOW_CREDENTIALS');
-  if (!showCredentials) {
-    let auth = options?.auth as { username?: string, password?: string };
-    if (auth?.password) {
-      auth.password = '*****';
-      options.auth = auth;
-    }
+  const hasPassword = options?.auth?.password;
+  if (!showCredentials && hasPassword) {
+    return formatJSon({
+      ...options,
+      auth: {
+        ...options.auth,
+        password: '*****'
+      }
+    })
   }
   return formatJSon(options);
 }


### PR DESCRIPTION
The current implementation to hide passwords from the test runner introduced in 2.0.2 via https://github.com/bahmutov/cy-api/issues/149 seems to mutate the original value of `auth.password` resulting in a request made with `*****`.

This is an attempt to fix the behavior.