### PR TITLE
fix: add a test for a long request to see the scroll

### DIFF
--- a/cypress/e2e/shows-credentials.cy.ts
+++ b/cypress/e2e/shows-credentials.cy.ts
@@ -24,4 +24,28 @@ describe('cy.api', () => {
       })
     },
   )
+
+  it(
+    'show very long credentials',
+    {
+      env: {
+        API_SHOW_CREDENTIALS: true,
+      },
+    },
+    () => {
+      cy.api({
+        url: '/',
+        auth: {
+          bearer: Cypress._.repeat('bearer_', 30),
+          username: 'login',
+          password: 'password',
+        },
+      }).then((response) => {
+        expect(response.status).eq(200)
+        cy.contains('"bearer": "bearer_bearer_')
+        cy.contains('"password": "password"')
+        // you should be able to scroll the container horizontally
+      })
+    },
+  )
 })


### PR DESCRIPTION
I added a test with a long bearer token to see if it can scroll the container, and it seems possible

https://user-images.githubusercontent.com/2212006/209010408-48f31840-8c52-4ec7-9f6f-5d4ae40a382a.mp4

I think the fix was released in v2.2.2
- closes #179 